### PR TITLE
Enhance posts "ruby-proc-lamda" and "ruby-precedence-in-block"

### DIFF
--- a/_posts/2019-05-12-ruby-proc-lambda.md
+++ b/_posts/2019-05-12-ruby-proc-lambda.md
@@ -52,7 +52,7 @@ A block, or [closure](https://en.wikipedia.org/wiki/Closure_(computer_programmin
 do puts 1 end # gets "SyntaxError"
 ```
 
-> Do you know there is difference between using `{ ... }` and `do ... end` block? Check out my blog post [Difference between "{}" & "do...end" in Ruby](/posts/ruby-precedence-in-block)!
+> Do you know there is difference between using `{ ... }` and `do ... end` block? Check out my blog post [Difference between "{}" & "do...end" in Ruby]({% post_url 2020-03-27-ruby-precedence-in-block %})!
 
 ## Proc and Lambda
 - [Definition](http://ruby-doc.org/core-2.6.3/Proc.html#class-Proc-label-Lambda+and+non-lambda+semantics){:rel="nofollow noopener noreferrer" target="_blank"} by ruby-doc.org

--- a/_posts/2019-05-12-ruby-proc-lambda.md
+++ b/_posts/2019-05-12-ruby-proc-lambda.md
@@ -1,6 +1,6 @@
 ---
 layout:     post
-title:      "Proc & Lambda in Ruby"
+title:      "Proc & Lambda in Ruby"
 date:       2019-05-12 00:00:00 +0800
 categories: ruby
 comments:   true

--- a/_posts/2020-03-27-ruby-precedence-in-block.md
+++ b/_posts/2020-03-27-ruby-precedence-in-block.md
@@ -40,18 +40,19 @@ In Ruby, a (code) block is a piece of code that takes arguments. A block can NOT
 
 ```ruby
 # Two ways to wrap a block in Ruby
-
-# Bad; will cause SyntaxError
+# They will cause errors if put like these
 # 1. { ... }
 { puts 1 } # gets "SyntaxError"
 # 2. do ... end
 do puts 1 end # gets "SyntaxError"
+```
 
+```ruby
 def some_method
   yield
 end
 
-# Good; will not cause SyntaxError
+# Good; these will not cause SyntaxError
 some_method { puts 1 }
 proc_print_one = proc { puts 1 }
 lambda_print_one = lambda { puts 1 }
@@ -60,7 +61,7 @@ lambda_print_one = lambda { puts 1 }
 > Read more about the difference between `proc` and `lambda` in my blog post [Proc & Lambda in Ruby]({% post_url 2019-05-12-ruby-proc-lambda %})!
 
 ## Precedence in Execution
-Per documentation in Ruby-Doc.org, `{ ... }` blocks have priority below all listed operations, but `do ... end` blocks have lower priority.
+Per documentation in Ruby-Doc.org, `{ ... }` blocks have priority below all [listed operations](https://ruby-doc.org/core-2.7.0/doc/syntax/precedence_rdoc.html){:rel="nofollow noopener noreferrer" target="_blank"}, but `do ... end` blocks have even lower priority.
 
 - No difference in terms of output, as all gets executed before printed
 

--- a/_posts/2020-03-27-ruby-precedence-in-block.md
+++ b/_posts/2020-03-27-ruby-precedence-in-block.md
@@ -36,7 +36,7 @@ end # => ???
 ```
 
 ## What is Block in Ruby
-In Ruby, a (code) block is a piece of code that takes arguments. A block can NOT "survive" its own inside, UNLESS it is attached to methods, or in the form of a proc/lambda.
+In Ruby, a (code) block is a piece of code that takes arguments. A block can NOT "survive" on its own, UNLESS it is attached to methods, or in the form of a proc/lambda.
 
 ```ruby
 # Two ways to wrap a block in Ruby
@@ -62,7 +62,7 @@ lambda_print_one = lambda { puts 1 }
 ## Precedence in Execution
 Per documentation in Ruby-Doc.org, `{ ... }` blocks have priority below all listed operations, but `do ... end` blocks have lower priority.
 
-- No difference in terms of output, as all gets excuted first before printed
+- No difference in terms of output, as all gets executed before printed
 
 ```ruby
 arr = [1, 2, 3]
@@ -90,7 +90,7 @@ puts arr.map do
 end # => #<Enumerator:0x00007fb34d8d40c0>
 ```
 
-See [Precedence](https://ruby-doc.org/core-2.7.0/doc/syntax/precedence_rdoc.html){:rel="nofollow noopener noreferrer" target="_blank"} for a conprehensive list of precedence.
+See [Precedence](https://ruby-doc.org/core-2.7.0/doc/syntax/precedence_rdoc.html){:rel="nofollow noopener noreferrer" target="_blank"} for the comprehensive list of precedence.
 
 ## References
 - [Precedence](https://ruby-doc.org/core-2.7.0/doc/syntax/precedence_rdoc.html){:rel="nofollow noopener noreferrer" target="_blank"} by Ruby-Doc.org

--- a/_posts/2020-03-27-ruby-precedence-in-block.md
+++ b/_posts/2020-03-27-ruby-precedence-in-block.md
@@ -36,7 +36,7 @@ end # => ???
 ```
 
 ## What is Block in Ruby
-In Ruby, a (code) block is a piece of code that takes arguments. A block can NOT "survive" on its own, UNLESS it is attached to methods, or in the form of a proc/lambda.
+In Ruby, a (code) block is a piece of code that takes arguments. A block can NOT "survive" on its own, UNLESS it is attached to methods, or in the form of `proc` or `lambda`.
 
 ```ruby
 # Two ways to wrap a block in Ruby
@@ -57,7 +57,7 @@ proc_print_one = proc { puts 1 }
 lambda_print_one = lambda { puts 1 }
 ```
 
-> Read more about the difference between a proc and a lambda in my blog post [Proc & Lambda in Ruby](/posts/ruby-proc-lambda)!
+> Read more about the difference between `proc` and `lambda` in my blog post [Proc & Lambda in Ruby](/posts/ruby-proc-lambda)!
 
 ## Precedence in Execution
 Per documentation in Ruby-Doc.org, `{ ... }` blocks have priority below all listed operations, but `do ... end` blocks have lower priority.

--- a/_posts/2020-03-27-ruby-precedence-in-block.md
+++ b/_posts/2020-03-27-ruby-precedence-in-block.md
@@ -57,7 +57,7 @@ proc_print_one = proc { puts 1 }
 lambda_print_one = lambda { puts 1 }
 ```
 
-> Read more about the difference between `proc` and `lambda` in my blog post [Proc & Lambda in Ruby](/posts/ruby-proc-lambda)!
+> Read more about the difference between `proc` and `lambda` in my blog post [Proc & Lambda in Ruby]({% post_url 2019-05-12-ruby-proc-lambda %})!
 
 ## Precedence in Execution
 Per documentation in Ruby-Doc.org, `{ ... }` blocks have priority below all listed operations, but `do ... end` blocks have lower priority.


### PR DESCRIPTION
### Changed
- Fix typo in post `ruby-precedence-in-block` (#37)
  - for a `conprehensive` list -> for the comprehensive list
  - gets `excuted` first before printed -> gets executed before printed
- Wrap `proc`/`lambda` in `` in post `ruby-precedence-in-block` (#37)
- Change hardcoded links to `post_urls` in posts (#37)
- Enhance content of `ruby-precedence-in-block` (#37)
  - What is Block in Ruby: Separate code blocks for better illustration of examples
  - Precedence in Execution: Add link to "listed operations" in the paragraph to disambiguate
- Remove nbsp in post `ruby-proc-lambda` (#29)
  > Note: nbsp was in title
