### PR TITLE
Fix typo in post heading

### DIFF
--- a/_posts/2019-05-14-ruby-super-super.md
+++ b/_posts/2019-05-14-ruby-super-super.md
@@ -7,7 +7,7 @@ comments:   true
 
 ---
 
-## TDLR
+## TLDR
 - `super` equals `super(*args)`, which brings ALL args to the inherited method
 - `super()`..., is just `super()` that simply invokes the inherited method
 

--- a/_posts/2020-03-22-vim8-terminal.md
+++ b/_posts/2020-03-22-vim8-terminal.md
@@ -8,7 +8,7 @@ comments:   true
 ---
 ![Terminal mode in Vim](/assets/images/vim8-terminal/1.png)
 
-## TDLR
+## TLDR
 - Vim 8.1 introduced terminal mode, `:terminal`
 - `:terminal` allows you to open terminals inside Vim, hence the potential to be as productive as being in a Tmux session
 - You probably don't need it if you are already using Tmux

--- a/_posts/2020-03-27-ruby-precedence-in-block.md
+++ b/_posts/2020-03-27-ruby-precedence-in-block.md
@@ -7,7 +7,7 @@ comments:   true
 
 ---
 
-## TDLR
+## TLDR
 - In Ruby, blocks in braces, `{ ... }`, bind stronger than in `do ... end` do
 - Rule of thumb
   1. Use `{ ... }` for single-line blocks

--- a/_posts/2020-04-11-resilient-css.md
+++ b/_posts/2020-04-11-resilient-css.md
@@ -9,7 +9,7 @@ comments:   true
 
 This is my summary for a YouTube series, [Resilient CSS](https://www.youtube.com/watch?v=u00FY9vADfQ&list=PLbSquHt1VCf1kpv9WRGMCA9_Nn4vCLZ9Y){:rel="nofollow noopener noreferrer" target="_blank"}.
 
-## TDLR
+## TLDR
 - Look up the stats of browser usage by region to define your device/browser support
   - Consult [caniuse.com](https://caniuse.com/){:rel="nofollow noopener noreferrer" target="_blank"}, [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS){:rel="nofollow noopener noreferrer" target="_blank"}, [Bugzilla](https://www.bugzilla.org/){:rel="nofollow noopener noreferrer" target="_blank"}, etc.
   - Browser usage can be measured by country in caniuse.com

--- a/_posts/2020-09-26-build-react-native-ios-app.md
+++ b/_posts/2020-09-26-build-react-native-ios-app.md
@@ -6,7 +6,7 @@ categories: ["react", "react-native", "ios"]
 comments:   true
 
 ---
-## TDLR
+## TLDR
 - ...you need a Mac to do it
 - Install Xcode, Node.js, and Yarn
 - Install Ruby gem `cocoapods`

--- a/_posts/2020-10-08-workshop-migrate-with-aws.md
+++ b/_posts/2020-10-08-workshop-migrate-with-aws.md
@@ -6,7 +6,7 @@ categories: ["workshop", "aws"]
 comments:   true
 
 ---
-## TDLR
+## TLDR
 These are notes taken from the workshop that covers the following:
 - Migrate database with AWS DMS (Database Migration Service)
 - Move on-premise or virtual instances onto EC2s with AWS CloudEndure


### PR DESCRIPTION
## Fixed
- Fix typo in post heading (credits to @MindyTai)
  - ruby-super-super
  - vim8-terminal
  - ruby-precedence-in-block
  - resilient-css
  - build-react-native-ios-app
  - workshop-migrate-with-aws