### PR TITLE
post: add release-age supply-chain guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tsconfig.tsbuildinfo
 tsconfig.test.tsbuildinfo
 .next
 .env
+.worktrees/
 
 # Playwright
 /test-results/

--- a/app/posts/(data)/2026-08-21-release-age-package-supply-chain-security.md
+++ b/app/posts/(data)/2026-08-21-release-age-package-supply-chain-security.md
@@ -1,0 +1,93 @@
+---
+title: 'Release-age controls: a low-friction supply-chain guard for pnpm and Python'
+summary: 'Delay freshly published packages during resolution, with narrow and auditable exceptions when an urgent fix cannot wait.'
+createdAt: 2026-08-21 19:51:40 +0800
+publishedAt: 2026-08-21
+categories: [javascript, python]
+---
+
+## TL;DR
+
+- A release-age rule delays **new resolution** of freshly uploaded packages. It gives maintainers, scanners, and the registry time to discover a bad release before it lands in my lockfile.
+- I use an explicit window (start at 24 hours; use longer when the deployment cadence allows it), keep exceptions narrow, and scan for vulnerabilities separately.
+- `pnpm`, `uv`, Poetry, and current `pip` all have a supported way to do this. Their configuration shapes are different enough that copying one manager's example into another is a footgun.
+
+This complements lockfiles, hash verification, review, and vulnerability scanning. It simply delays “published” becoming “eligible for my next update.”
+
+## pnpm: make the cooling-off period strict
+
+`minimumReleaseAge` is measured in minutes and covers direct and transitive dependencies. pnpm 11 defaults to 1,440 minutes, but I set it explicitly because older pnpm versions defaulted to no delay.
+
+```yaml
+# pnpm-workspace.yaml
+minimumReleaseAge: 1440
+minimumReleaseAgeStrict: true
+```
+
+It makes an unsatisfied age constraint fail resolution instead of falling back to a too-new version.
+
+When an urgent fix genuinely cannot wait, I make the exception as small as possible. A bare package name exempts every version, so it is usually too broad:
+
+```yaml
+minimumReleaseAge: 1440
+minimumReleaseAgeStrict: true
+minimumReleaseAgeExclude:
+  - 'webpack@5.102.1'
+```
+
+Version selectors arrived in pnpm 10.19. An exact version is the safer emergency escape hatch; remove it once the normal window passes.
+
+See pnpm's [release-age settings](https://pnpm.io/settings/dependency-resolution#minimumreleaseage) and [workspace configuration](https://pnpm.io/settings) for the current behaviour.
+
+## uv: use a duration, then opt out only when needed
+
+uv calls this `exclude-newer` and filters individual distribution artifacts by upload time. A duration fits a rolling policy:
+
+```toml
+# pyproject.toml
+[tool.uv]
+exclude-newer = "7 days"
+```
+
+The documented package-level override is `exclude-newer-package`, not `exclude-newer-exceptions`. A package can have its own age or be explicitly opted out of the global restriction:
+
+```toml
+[tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = { setuptools = false }
+```
+
+Treat `false` as a temporary escape hatch. uv needs registry upload-time metadata; PyPI provides it, while private indexes may need an index-specific policy. The [uv resolution documentation](https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns) covers duration formats and precedence.
+
+## Poetry: configure the solver, not `pyproject.toml`
+
+Poetry 2.4 introduced `solver.min-release-age`, measured in whole days. It is application configuration, so a project-scoped policy belongs in `poetry.toml` via `--local`, separate from `pyproject.toml`:
+
+```bash
+poetry config solver.min-release-age 7 --local
+poetry config solver.min-release-age-exclude "my-emergency-package" --local
+```
+
+The exclusion is a comma-separated list of names and permits all versions of those packages. The filter only works for sources that expose upload timestamps.
+
+Poetry's [solver configuration](https://python-poetry.org/docs/configuration/#solvermin-release-age) documents the setting, its source-metadata limitation, and the exclusion form.
+
+## pip: current pip can do this too
+
+Raw pip now has `--uploaded-prior-to`. pip 26.0 introduced the upload-time filter, and 26.1 added the duration syntax, so this is no longer an absolute-date-only workaround:
+
+```bash
+python -m pip install --uploaded-prior-to=P7D -r requirements.txt
+```
+
+For a fixed, reproducible cutoff, I can use UTC instead:
+
+```bash
+python -m pip install --uploaded-prior-to=2026-08-14T00:00:00Z -r requirements.txt
+```
+
+pip has no per-package release-age allowlist here. The filter only applies to remote indexes with upload-time metadata; local files and VCS requirements are outside it. Read the [pip upload-time guide](https://pip.pypa.io/en/stable/user_guide/#filtering-by-upload-time) before putting it in CI.
+
+## Make the delay useful
+
+Lockfiles still matter: I review lockfile updates, make upgrades intentional, and run vulnerability scanning on a schedule. An age window delays security fixes too, so the emergency path should be visible, narrow, and later removed.

--- a/app/posts/(data)/2026-08-21-release-age-package-supply-chain-security.md
+++ b/app/posts/(data)/2026-08-21-release-age-package-supply-chain-security.md
@@ -8,15 +8,15 @@ categories: [javascript, python]
 
 ## TL;DR
 
-- A release-age rule delays **new resolution** of freshly uploaded packages. It gives maintainers, scanners, and the registry time to discover a bad release before it lands in my lockfile.
-- I use an explicit window (start at 24 hours; use longer when the deployment cadence allows it), keep exceptions narrow, and scan for vulnerabilities separately.
-- `pnpm`, `uv`, Poetry, and current `pip` all have a supported way to do this. Their configuration shapes are different enough that copying one manager's example into another is a footgun.
+- Do not let every new package release become eligible the instant it is published. A one-day or one-week cooling-off period gives maintainers and scanners time to find a bad release.
+- This protects **new resolution**, not code already selected in a lockfile. Keep lockfiles, review their diffs, and scan independently.
+- pnpm, uv, Poetry, and pip have different controls. Use the native setting; do not copy a pnpm allowlist into a Python tool.
 
-This complements lockfiles, hash verification, review, and vulnerability scanning. It simply delays “published” becoming “eligible for my next update.”
+A release-age policy is a small supply-chain control with a useful failure mode: an upgrade waits rather than silently picking a package published minutes ago. It is not a replacement for hashes, review, or vulnerability scanning. It also delays legitimate security fixes, so the escape hatch needs an owner and an expiry.
 
-## pnpm: make the cooling-off period strict
+## pnpm: delay new versions, including transitive ones
 
-`minimumReleaseAge` is measured in minutes and covers direct and transitive dependencies. pnpm 11 defaults to 1,440 minutes, but I set it explicitly because older pnpm versions defaulted to no delay.
+[`minimumReleaseAge`](https://pnpm.io/settings/dependency-resolution#minimumreleaseage) is measured in minutes and applies to direct and transitive dependencies. pnpm 11+ defaults it to 1,440 minutes, but I set it explicitly so the policy does not depend on the installed pnpm major version.
 
 ```yaml
 # pnpm-workspace.yaml
@@ -24,9 +24,9 @@ minimumReleaseAge: 1440
 minimumReleaseAgeStrict: true
 ```
 
-It makes an unsatisfied age constraint fail resolution instead of falling back to a too-new version.
+Strict mode makes resolution fail when nothing in the requested range is old enough. That is the useful behaviour in CI: choosing a too-new version would defeat the rule. It is already the default when `minimumReleaseAge` is configured explicitly; keeping it in the file makes the intent obvious.
 
-When an urgent fix genuinely cannot wait, I make the exception as small as possible. A bare package name exempts every version, so it is usually too broad:
+For an urgent fix, exempt the smallest possible target. A package name exempts every version, while an exact version limits the exception:
 
 ```yaml
 minimumReleaseAge: 1440
@@ -35,13 +35,11 @@ minimumReleaseAgeExclude:
   - 'webpack@5.102.1'
 ```
 
-Version selectors arrived in pnpm 10.19. An exact version is the safer emergency escape hatch; remove it once the normal window passes.
+Version-specific exclusions require pnpm 10.19 or newer. Remove the entry after the normal window has passed. The [pnpm documentation](https://pnpm.io/settings/dependency-resolution#minimumreleaseageexclude) also documents name and scope patterns, but they are deliberately broader than an emergency exception should be.
 
-See pnpm's [release-age settings](https://pnpm.io/settings/dependency-resolution#minimumreleaseage) and [workspace configuration](https://pnpm.io/settings) for the current behaviour.
+## uv: use a rolling cooldown
 
-## uv: use a duration, then opt out only when needed
-
-uv calls this `exclude-newer` and filters individual distribution artifacts by upload time. A duration fits a rolling policy:
+uv calls the setting [`exclude-newer`](https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns). It compares each distribution artifact's upload time, not a package version's release time.
 
 ```toml
 # pyproject.toml
@@ -49,7 +47,7 @@ uv calls this `exclude-newer` and filters individual distribution artifacts by u
 exclude-newer = "7 days"
 ```
 
-The documented package-level override is `exclude-newer-package`, not `exclude-newer-exceptions`. A package can have its own age or be explicitly opted out of the global restriction:
+A package can use a different cutoff or opt out of the global one. `false` is an explicit bypass, so I treat it as temporary:
 
 ```toml
 [tool.uv]
@@ -57,37 +55,35 @@ exclude-newer = "7 days"
 exclude-newer-package = { setuptools = false }
 ```
 
-Treat `false` as a temporary escape hatch. uv needs registry upload-time metadata; PyPI provides it, while private indexes may need an index-specific policy. The [uv resolution documentation](https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns) covers duration formats and precedence.
+PyPI exposes upload times. For an index without them, uv can use an index-specific cutoff or opt that index out; decide that deliberately rather than assuming the global policy covers private packages. The filter applies to registry packages, not Git dependencies.
 
-## Poetry: configure the solver, not `pyproject.toml`
+## Poetry: configure the application solver
 
-Poetry 2.4 introduced `solver.min-release-age`, measured in whole days. It is application configuration, so a project-scoped policy belongs in `poetry.toml` via `--local`, separate from `pyproject.toml`:
+Poetry 2.4 introduced [`solver.min-release-age`](https://python-poetry.org/docs/configuration/#solvermin-release-age). It is application configuration, so project-local settings go in `poetry.toml`, not `pyproject.toml`:
 
 ```bash
 poetry config solver.min-release-age 7 --local
 poetry config solver.min-release-age-exclude "my-emergency-package" --local
 ```
 
-The exclusion is a comma-separated list of names and permits all versions of those packages. The filter only works for sources that expose upload timestamps.
+The age is in whole days. Poetry ignores a release when any known distribution file is newer than the configured age; it can only enforce the rule for sources that expose upload timestamps. The exclusion is a comma-separated list of package names and permits all of their versions, so keep it short and review it.
 
-Poetry's [solver configuration](https://python-poetry.org/docs/configuration/#solvermin-release-age) documents the setting, its source-metadata limitation, and the exclusion form.
+## pip: use an upload-time cutoff
 
-## pip: current pip can do this too
-
-Raw pip now has `--uploaded-prior-to`. pip 26.0 introduced the upload-time filter, and 26.1 added the duration syntax, so this is no longer an absolute-date-only workaround:
+[pip 26.0 added `--uploaded-prior-to`](https://pip.pypa.io/en/stable/user_guide/#filtering-by-upload-time); pip 26.1 also accepts a duration. For a seven-day rolling policy:
 
 ```bash
 python -m pip install --uploaded-prior-to=P7D -r requirements.txt
 ```
 
-For a fixed, reproducible cutoff, I can use UTC instead:
+For a fixed, reproducible cutoff, use a UTC timestamp instead:
 
 ```bash
 python -m pip install --uploaded-prior-to=2026-08-14T00:00:00Z -r requirements.txt
 ```
 
-pip has no per-package release-age allowlist here. The filter only applies to remote indexes with upload-time metadata; local files and VCS requirements are outside it. Read the [pip upload-time guide](https://pip.pypa.io/en/stable/user_guide/#filtering-by-upload-time) before putting it in CI.
+pip has no per-package bypass for this filter. It applies only to remote indexes that provide upload-time metadata; local files and VCS requirements are allowed, and an index that lacks the metadata fails the install.
 
-## Make the delay useful
+## Keep the exception path boring
 
-Lockfiles still matter: I review lockfile updates, make upgrades intentional, and run vulnerability scanning on a schedule. An age window delays security fixes too, so the emergency path should be visible, narrow, and later removed.
+An age gate is most useful when dependency updates are intentional: review the lockfile diff, run a vulnerability scanner, and record why an exception exists. A compromised release might be discovered during the wait; a real security fix might need the exception. In both cases, the follow-up is the same: remove the exception and let the normal policy take over.


### PR DESCRIPTION
## Summary
- add a practical guide to release-age supply-chain controls
- cover pnpm, uv, Poetry, and pip with official sources

## Verification
- post loader front-matter/discovery check
- pnpm build
- pnpm test
- browser verification of the rendered post